### PR TITLE
Build Docker images.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:14.04
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    echo debconf shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
+    echo debconf shared/accepted-oracle-license-v1-1 seen true | debconf-set-selections && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository ppa:webupd8team/java && \
+    apt-get purge -y software-properties-common && \
+    apt-get autoremove -y --purge && \
+    apt-get clean
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install -y oracle-java8-installer && \
+    apt-get clean
+
+ENV JAVA_OPTS -Xmx512m

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # Docker image for Java on Ubuntu
 
 ![Build Status](https://circleci.com/gh/login-box/docker-ubuntu-java.svg?style=shield&circle-token=28b90bc76f8ea447b92bbfe2db7ff9415113207c)
+
+**You must build these images for yourself.** They rely on the Oracle JDK
+packages; you'll have to decide for yourself whether to accept their license
+agreement.
+
+## To Build
+
+`docker build --tag MYNAME/ubuntu-java .`
+
+## Contents
+
+* Ubuntu 14.04 LTS (from `ubuntu:14.04` at the time of packaging)
+* Oracle Java 8 JDK (from [the webupd8 team's PPA](http://www.webupd8.org/p/ubuntu-ppas-by-webupd8.html))
+* The `JAVA_OPTS` enviroment variable, which is set to `-Xmx512m` by default. (Override this in your own Dockerfile, or at startup with `--env`/`--env-file`)

--- a/bin/build
+++ b/bin/build
@@ -1,3 +1,4 @@
 #!/bin/bash -e
 
-true
+cd "$(dirname "$0")/.."
+exec docker build -t loginbox/ubuntu-java .

--- a/bin/test
+++ b/bin/test
@@ -1,12 +1,14 @@
 #!/bin/bash -e
 
-docker run --rm -i login-box/ubuntu-java <<'TEST_SCRIPT'
+RM=${RM:---rm}
+
+docker run -i ${RM} loginbox/ubuntu-java <<'TEST_SCRIPT'
 set -ex
 java -version
 javac -version
 TEST_SCRIPT
 
-docker run --rm -i login-box/ubuntu-java <<'TEST_SCRIPT'
+docker run -i ${RM} loginbox/ubuntu-java <<'TEST_SCRIPT'
 set -ex
 mkdir -p /tests/hello
 cd /tests/hello

--- a/bin/test
+++ b/bin/test
@@ -1,3 +1,24 @@
 #!/bin/bash -e
 
-true
+docker run --rm -i login-box/ubuntu-java <<'TEST_SCRIPT'
+set -ex
+java -version
+javac -version
+TEST_SCRIPT
+
+docker run --rm -i login-box/ubuntu-java <<'TEST_SCRIPT'
+set -ex
+mkdir -p /tests/hello
+cd /tests/hello
+
+cat > Hello.java <<'HELLO_JAVA'
+class Hello {
+    public static void main(String... args) {
+        System.out.println("Hello, world!");
+    }
+}
+HELLO_JAVA
+
+javac Hello.java
+java Hello
+TEST_SCRIPT

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,11 @@
+machine:
+    services:
+        - docker
+
 dependencies:
     override:
         - bin/build
 
 test:
     override:
-        - bin/test
+        - RM=-- bin/test


### PR DESCRIPTION
I've opted to use the webupd8 team's PPA, rather than the JDK tarballs, so that
I don't have to screw around configuring `/etc/alternatives`. This has a fairly
signifigant size tradeoff, and complicates the Dockerfile.